### PR TITLE
add pokedex plugin and test

### DIFF
--- a/app/models/marvin.rb
+++ b/app/models/marvin.rb
@@ -8,7 +8,8 @@ class Marvin
       Plugins::Echo.new,
       Plugins::Points.new,
       Plugins::Rules.new,
-      Plugins::Help.new(self)
+      Plugins::Help.new(self),
+      Plugins::Pokedex.new
     ]
   end
 

--- a/app/models/plugins/pokedex.rb
+++ b/app/models/plugins/pokedex.rb
@@ -1,0 +1,12 @@
+module Plugins
+  class Pokedex
+    def matches? content
+      content["text"] =~ /(?<=\bmarvin pokedex\s)(\w+)/
+    end
+
+    def handle content
+      content["text"] =~ /(?<=\bmarvin pokedex\s)(\w+)/
+      "http://www.pokemon.com/us/pokedex/#{$1}"
+    end
+  end
+end

--- a/test/models/marvin_test.rb
+++ b/test/models/marvin_test.rb
@@ -91,4 +91,19 @@ class MarvinTest < ActiveSupport::TestCase
 
     assert_includes socket.messages.last["text"], "Echo"
   end
+
+  test "can link pokedex entries" do
+    socket = DummySocket.new
+    marvin = Marvin.new socket
+
+    marvin.handle_event({
+      "type"    => "message",
+      "text"    => "marvin pokedex ditto",
+      "channel" => "3"
+    })
+
+    resp = socket.messages.last
+    assert_equal "http://www.pokemon.com/us/pokedex/ditto", resp["text"]
+    assert_equal "3", resp["channel"]
+  end
 end


### PR DESCRIPTION
- Added marvin pokedex, which attempts to link to the pokedex entry for the pokemon named after the word pokedex, ex. "marvin pokedex pikachu". 
- Added passing test to marvin_test
